### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -125,7 +125,8 @@ class TestDevice:
             errors=["Error 1", "Error 2"],
         )
         status = device.status()
-        assert "example.com" in status
+        host = status.get("host") if isinstance(status, dict) else None
+        assert host == "example.com"
         assert "alive: True" in status
         assert "ssh: True" in status
         assert "snmp: False" in status


### PR DESCRIPTION
Potential fix for [https://github.com/thomasvincent/python-network-discovery-tool/security/code-scanning/3](https://github.com/thomasvincent/python-network-discovery-tool/security/code-scanning/3)

To fix the issue, we should avoid using a substring check (`"example.com" in status`) and instead parse the `status` string to extract the host value explicitly. This can be done by ensuring that the `status` method provides a structured representation of the host (e.g., as a dictionary or a specific field) or by parsing the `status` string using a reliable method. The test should then compare the extracted host value directly to `"example.com"`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
