### PR TITLE
Potential fix for code scanning alert no. 2: Accepting unknown SSH host keys when using Paramiko

### DIFF
--- a/device.py
+++ b/device.py
@@ -5,7 +5,7 @@ from typing import Optional, List, Any
 from twisted.internet import defer, task
 from twisted.python import log as twisted_log
 from snimpy.manager import Manager as M, load
-from paramiko import SSHClient, AutoAddPolicy
+from paramiko import SSHClient, RejectPolicy
 from paramiko.ssh_exception import AuthenticationException, SSHException
 import MySQLdb
 
@@ -223,7 +223,7 @@ class SSHHelper:
         """Connects to the host via SSH and runs a command."""
         ssh = SSHClient()
         ssh.load_host_keys(KEY_FILE)
-        ssh.set_missing_host_key_policy(AutoAddPolicy())
+        ssh.set_missing_host_key_policy(RejectPolicy())
         try:
             ssh.connect(host, username=user, timeout=3)
             stdin, stdout, stderr = ssh.exec_command(command)


### PR DESCRIPTION
Potential fix for [https://github.com/thomasvincent/python-network-discovery-tool/security/code-scanning/2](https://github.com/thomasvincent/python-network-discovery-tool/security/code-scanning/2)

To fix the issue, replace the use of `AutoAddPolicy` with a secure alternative. The best approach is to use `RejectPolicy`, which ensures that the application will throw an exception if the host key is unknown. This forces the application to validate the server's identity before proceeding. Additionally, ensure that the `load_host_keys` method is correctly loading a known hosts file, and handle exceptions appropriately to provide meaningful error messages.

Changes to be made:
1. Replace `AutoAddPolicy` with `RejectPolicy`.
2. Ensure the `load_host_keys` method is loading a valid known hosts file.
3. Update the imports to include `RejectPolicy`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
