### PR TITLE
fix: add missing dependencies to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,9 @@ PyMySQL>=1.0.0
 asyncio>=3.4.3
 python-libnmap>=0.7.3
 ijson>=3.1.4
+pydantic>=2.7.0
+pydantic-settings>=2.9.0
+typer>=0.9.0
 
 # Optional dependencies
 # mysqlclient>=2.0.0  # Requires MySQL development libraries


### PR DESCRIPTION
This PR adds the missing dependencies to requirements.txt that were needed for Docker build and CI tests:

- pydantic>=2.7.0
- pydantic-settings>=2.9.0 
- typer>=0.9.0

These dependencies are used by the new settings module with Pydantic validation and the Typer-based CLI.